### PR TITLE
Adds README as main index page of docs

### DIFF
--- a/docs/content/rctab-readme.md
+++ b/docs/content/rctab-readme.md
@@ -1,5 +1,0 @@
-
-
-```{include} ../../README.md
-:relative-images:
-```

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,19 +3,18 @@
 % You can adapt this file completely to your liking, but it should at least
 % contain the root `toctree` directive.
 
-# Welcome to RCTab
-
 ```{warning}
 🚧 This documentation is under construction 🚧
 ```
 
-An Azure subscription management, reporting, and usage monitoring system. Created by The Institute.
+```{include} ../README.md
+:relative-images:
+```
 
 ```{toctree}
 :hidden:
 :maxdepth: 2
 :glob:
-content/rctab-readme.md
 content/contributing.md
 ```
 


### PR DESCRIPTION
Adds high level docs and rational to the README and puts this as the main index content.

closes #13 